### PR TITLE
[VIVO-1670] - Disable Step 2 and Internationalization

### DIFF
--- a/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
+++ b/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
@@ -810,3 +810,47 @@ presentation_name_capitalized=Titel der Präsentation
 role_in_presentation_capitalized=Rolle in der Präsentation
 advisee_capitalized_first_name=Vorname
 advisee_capitalized_lastname=Nachname
+
+add_orcid_id=Add an iD
+
+orcid_title_add = Do you want to add an ORCID iD?
+orcid_step1_add = Step 1: Adding your ORCID iD
+orcid_title_confirm = Do you want to add an ORCID iD?
+orcid_step1_confirm = Step 1: Adding your ORCID iD
+
+orcid_step1_description = <ul><li>VIVO redirects you to ORCID's web site.</li> \
+<li>You log in to your ORCID account. <ul class="inner"><li>If you don't have an account, you can create one.</li></ul></li> \
+<li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li> \
+<li>VIVO reads your ORCID record.</li> \
+<li>VIVO notes that your ORCID iD is confirmed.</li></ul>
+
+orcid_step1_denied = <p>You denied VIVO's request to read your ORCID record.</p> \
+<p>Confirmation can't continue.</p>
+
+orcid_step1_failed = <p>VIVO failed to read your ORCID record.</p> \
+<p>Confirmation can't continue.</p>
+
+orcid_step1_confirmed = <p>Your ORCID iD is confirmed as {0}</p>
+
+orcid_step2_heading = Step 2 (recommended): Linking your ORCID record to VIVO
+
+orcid_step2_description = <ul><li>VIVO redirects you to ORCID's web site</li> \
+<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li> \
+<li>VIVO adds the external ID.</li></ul> 
+
+orcid_step2_already_present = <p>Your ORCID record already includes a link to VIVO.</p>
+
+orcid_step2_denied = <p>You denied VIVO's request to add an External ID to your ORCID record.</p> \
+<p>Linking can't continue.</p>
+
+orcid_step2_failed = <p>VIVO failed to add an External ID to your ORCID record.</p> \
+<p>Linking can't continue.</p>
+
+orcid_step2_added = <p>Your ORCID record is linked to VIVO</p>
+
+orcid_button_step1 = Continue Step 1
+orcid_button_step2 = Continue Step 2
+
+orcid_step_completed = (step completed)
+orcid_view_orcid_record = View your ORCID record.
+orcid_return_to_vivo = Return to your VIVO profile page

--- a/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
+++ b/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
@@ -810,3 +810,47 @@ presentation_name_capitalized=Title of Presentation
 role_in_presentation_capitalized=Role in Presentation
 advisee_capitalized_first_name=First Name
 advisee_capitalized_lastname=Last Name
+
+add_orcid_id=Add an iD
+
+orcid_title_add = Do you want to add an ORCID iD?
+orcid_step1_add = Step 1: Adding your ORCID iD
+orcid_title_confirm = Do you want to add an ORCID iD?
+orcid_step1_confirm = Step 1: Adding your ORCID iD
+
+orcid_step1_description = <ul><li>VIVO redirects you to ORCID's web site.</li> \
+<li>You log in to your ORCID account. <ul class="inner"><li>If you don't have an account, you can create one.</li></ul></li> \
+<li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li> \
+<li>VIVO reads your ORCID record.</li> \
+<li>VIVO notes that your ORCID iD is confirmed.</li></ul>
+
+orcid_step1_denied = <p>You denied VIVO's request to read your ORCID record.</p> \
+<p>Confirmation can't continue.</p>
+
+orcid_step1_failed = <p>VIVO failed to read your ORCID record.</p> \
+<p>Confirmation can't continue.</p>
+
+orcid_step1_confirmed = <p>Your ORCID iD is confirmed as {0}</p>
+
+orcid_step2_heading = Step 2 (recommended): Linking your ORCID record to VIVO
+
+orcid_step2_description = <ul><li>VIVO redirects you to ORCID's web site</li> \
+<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li> \
+<li>VIVO adds the external ID.</li></ul> 
+
+orcid_step2_already_present = <p>Your ORCID record already includes a link to VIVO.</p>
+
+orcid_step2_denied = <p>You denied VIVO's request to add an External ID to your ORCID record.</p> \
+<p>Linking can't continue.</p>
+
+orcid_step2_failed = <p>VIVO failed to add an External ID to your ORCID record.</p> \
+<p>Linking can't continue.</p>
+
+orcid_step2_added = <p>Your ORCID record is linked to VIVO</p>
+
+orcid_button_step1 = Continue Step 1
+orcid_button_step2 = Continue Step 2
+
+orcid_step_completed = (step completed)
+orcid_view_orcid_record = View your ORCID record.
+orcid_return_to_vivo = Return to your VIVO profile page

--- a/webapp/src/main/webapp/i18n/vivo_all_es.properties
+++ b/webapp/src/main/webapp/i18n/vivo_all_es.properties
@@ -812,3 +812,47 @@ presentation_name_capitalized=Title of Presentation
 role_in_presentation_capitalized=Role in Presentation
 advisee_capitalized_first_name=First Name
 advisee_capitalized_lastname=Last Name
+
+add_orcid_id=Add an iD
+
+orcid_title_add = Do you want to add an ORCID iD?
+orcid_step1_add = Step 1: Adding your ORCID iD
+orcid_title_confirm = Do you want to add an ORCID iD?
+orcid_step1_confirm = Step 1: Adding your ORCID iD
+
+orcid_step1_description = <ul><li>VIVO redirects you to ORCID's web site.</li> \
+<li>You log in to your ORCID account. <ul class="inner"><li>If you don't have an account, you can create one.</li></ul></li> \
+<li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li> \
+<li>VIVO reads your ORCID record.</li> \
+<li>VIVO notes that your ORCID iD is confirmed.</li></ul>
+
+orcid_step1_denied = <p>You denied VIVO's request to read your ORCID record.</p> \
+<p>Confirmation can't continue.</p>
+
+orcid_step1_failed = <p>VIVO failed to read your ORCID record.</p> \
+<p>Confirmation can't continue.</p>
+
+orcid_step1_confirmed = <p>Your ORCID iD is confirmed as {0}</p>
+
+orcid_step2_heading = Step 2 (recommended): Linking your ORCID record to VIVO
+
+orcid_step2_description = <ul><li>VIVO redirects you to ORCID's web site</li> \
+<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li> \
+<li>VIVO adds the external ID.</li></ul> 
+
+orcid_step2_already_present = <p>Your ORCID record already includes a link to VIVO.</p>
+
+orcid_step2_denied = <p>You denied VIVO's request to add an External ID to your ORCID record.</p> \
+<p>Linking can't continue.</p>
+
+orcid_step2_failed = <p>VIVO failed to add an External ID to your ORCID record.</p> \
+<p>Linking can't continue.</p>
+
+orcid_step2_added = <p>Your ORCID record is linked to VIVO</p>
+
+orcid_button_step1 = Continue Step 1
+orcid_button_step2 = Continue Step 2
+
+orcid_step_completed = (step completed)
+orcid_view_orcid_record = View your ORCID record.
+orcid_return_to_vivo = Return to your VIVO profile page

--- a/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
+++ b/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
@@ -811,3 +811,47 @@ presentation_name_capitalized=Title of Presentation
 role_in_presentation_capitalized=Role in Presentation
 advisee_capitalized_first_name=First Name
 advisee_capitalized_lastname=Last Name
+
+add_orcid_id=Add an iD
+
+orcid_title_add = Do you want to add an ORCID iD?
+orcid_step1_add = Step 1: Adding your ORCID iD
+orcid_title_confirm = Do you want to add an ORCID iD?
+orcid_step1_confirm = Step 1: Adding your ORCID iD
+
+orcid_step1_description = <ul><li>VIVO redirects you to ORCID's web site.</li> \
+<li>You log in to your ORCID account. <ul class="inner"><li>If you don't have an account, you can create one.</li></ul></li> \
+<li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li> \
+<li>VIVO reads your ORCID record.</li> \
+<li>VIVO notes that your ORCID iD is confirmed.</li></ul>
+
+orcid_step1_denied = <p>You denied VIVO's request to read your ORCID record.</p> \
+<p>Confirmation can't continue.</p>
+
+orcid_step1_failed = <p>VIVO failed to read your ORCID record.</p> \
+<p>Confirmation can't continue.</p>
+
+orcid_step1_confirmed = <p>Your ORCID iD is confirmed as {0}</p>
+
+orcid_step2_heading = Step 2 (recommended): Linking your ORCID record to VIVO
+
+orcid_step2_description = <ul><li>VIVO redirects you to ORCID's web site</li> \
+<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li> \
+<li>VIVO adds the external ID.</li></ul> 
+
+orcid_step2_already_present = <p>Your ORCID record already includes a link to VIVO.</p>
+
+orcid_step2_denied = <p>You denied VIVO's request to add an External ID to your ORCID record.</p> \
+<p>Linking can't continue.</p>
+
+orcid_step2_failed = <p>VIVO failed to add an External ID to your ORCID record.</p> \
+<p>Linking can't continue.</p>
+
+orcid_step2_added = <p>Your ORCID record is linked to VIVO</p>
+
+orcid_button_step1 = Continue Step 1
+orcid_button_step2 = Continue Step 2
+
+orcid_step_completed = (step completed)
+orcid_view_orcid_record = View your ORCID record.
+orcid_return_to_vivo = Return to your VIVO profile page


### PR DESCRIPTION
i18n strings for VIVO-1670 (untranslated)

For discussion, see:
https://jira.duraspace.org/browse/VIVO-1670
https://github.com/vivo-project/VIVO/pull/130