### PR TITLE
Modified .ftl files to minimize usage of concatenated labels

### DIFF
--- a/fr_CA/webapp/src/main/webapp/i18n/vivo_all_fr_CA.properties
+++ b/fr_CA/webapp/src/main/webapp/i18n/vivo_all_fr_CA.properties
@@ -239,7 +239,7 @@ year_hint_format = AAAA
 
 collection_series_editor_role = Rôle d'éditeur(-trice) de collection
 editor_role_in = rôle d'éditeur(-trice) dans
-collection_or_series = la collection ou la série
+collection_or_series = collection ou série
 
 edit_wbpage_of = Éditer la page web de
 add_webpage_for = Ajouter la page web de
@@ -407,6 +407,7 @@ select_an_organization_name = SVP, choisir une entrée existante ou en saisir un
 select_educational_training_value = SVP, choisir une entrée dans le champ Type de formation pédagogique.
 org_type_capitalized = Type d'organisation
 educational_training_type = Type de formation pédagogique
+educational_training = formation pédagogique
 dept_or_school_name = Nom du département ou de l'école dans
 degree = Diplôme
 missing_degree = diplôme manquant

--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditorshipToPerson_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addEditorshipToPerson_fr_CA.ftl
@@ -80,8 +80,8 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     <form id="addEditorshipToPerson" class="customForm noIE67" action="${submitUrl}"  role="add/edit editorship">
 
 
-    <p class="inline">
-        <label for="orgType">${i18n().document_type_capitalized} ${requiredHint}</label>
+    <p>
+        <label for="orgType" class="inline">${i18n().document_type_capitalized} ${requiredHint}</label>
         <#assign docTypeOpts = editConfiguration.pageData.documentType />
         <select id="typeSelector" name="documentType" acGroupName="document">
             <option value="" selected="selected">${i18n().select_one}</option>
@@ -96,7 +96,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     </p>
 
     <p>
-        <label for="relatedIndLabel">${i18n().document_name_capitalized} ${requiredHint}</label>
+        <label for="relatedIndLabel" class="inline">${i18n().document_name_capitalized} ${requiredHint}</label>
         <input class="acSelector" size="50"  type="text" id="relatedIndLabel" name="documentLabel" acGroupName="document" value="${documentLabelValue}"  />
         <input class="display" type="hidden" id="documentDisplay" acGroupName="document" name="documentLabelDisplay" value="${documentLabelDisplayValue}">
     </p>

--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addPresenterRoleToPerson_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addPresenterRoleToPerson_fr_CA.ftl
@@ -98,8 +98,8 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 <section id="addPresenterRoleToPerson" role="region">
 
     <form id="addPresenterRoleToPerson" class="customForm noIE67" action="${submitUrl}"  role="add/edit Presentation">
-    <p class="inline">
-      <label for="presentationType">${i18n().presentation_type}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
+    <p>
+      <label for="presentationType" class="inline">${i18n().presentation_type}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
       <#assign presentationTypeOpts = editConfiguration.pageData.presentationType />
       <select id="typeSelector" name="presentationType" acGroupName="presentation">
         <option value="" selected="selected">${i18n().select_one}</option>
@@ -110,14 +110,14 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     </p>
 
     <p>
-        <label for="presentation">${i18n().presentation_name_capitalized} ${requiredHint}</label>
+        <label for="presentation" class="inline">${i18n().presentation_name_capitalized} ${requiredHint}</label>
             <input class="acSelector" size="50"  type="text" id="presentation" acGroupName="presentation" name="presentationLabel" value="${presentationLabelValue}">
             <input class="display" type="hidden" id="presentationDisplay" acGroupName="presentation" name="presentationLabelDisplay" value="${presentationLabelDisplayValue}">
     </p>
 
     <div class="acSelection" acGroupName="presentation">
-        <p class="inline">
-            <label>${i18n().selected}:</label>
+        <p>
+            <label class="inline">${i18n().selected_presentation}:</label>
             <span class="acSelectionInfo"></span>
             <a href="" class="verifyMatch"  title="${i18n().verify_match_capitalized}">(${i18n().verify_match_capitalized}</a> ${i18n().or}
             <a href="#" class="changeSelection" id="changeSelection">${i18n().change_selection})</a>
@@ -134,8 +134,8 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
       <input  class="display" acGroupName="conference" type="hidden" id="conferenceDisplay" name="conferenceLabelDisplay" value="${conferenceLabelDisplayValue}" />
   </p>
   <div class="acSelection" acGroupName="conference">
-      <p class="inline">
-          <label>${i18n().selected_conference}:</label>
+      <p>
+          <label  class="inline">${i18n().selected_conference}:</label>
           <span class="acSelectionInfo"></span>
           <a href="" class="verifyMatch"  title="${i18n().verify_match_capitalized}">(${i18n().verify_match_capitalized}</a> ${i18n().or}
           <a href="#" class="changeSelection" id="changeSelection">${i18n().change_selection})</a>
@@ -143,7 +143,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
       <input class="acUriReceiver" type="hidden" id="conferenceUri" name="existingConference" value="${conferenceValue}" ${flagClearLabelForExisting}="true" />
   </div>
     <p>
-        <h4 class="label">${i18n().years_participating}</h4>
+        <h3 class="label">${i18n().years_participating}</h3>
     </p>
     <#--Need to draw edit elements for dates here-->
     <#assign htmlForElements = editConfiguration.pageData.htmlForElements />

--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addPublicationToPerson_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addPublicationToPerson_fr_CA.ftl
@@ -130,7 +130,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 <form id="addpublicationToPerson" class="customForm noIE67" action="${submitUrl}"  role="add/edit publication">
 
         <#--TODO: Check if possible to have existing publication options here in order to select-->
-    <p class="inline"><label for="typeSelector">${i18n().publication_type}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
+    <p><label for="typeSelector" class="inline">${i18n().publication_type}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
         <select id="typeSelector" name="pubType" acGroupName="publication" >
              <option value="" <#if (publicationTypeValue?length = 0)>selected="selected"</#if>>${i18n().select_one}</option>
              <#list pubTypeLiteralOptions?keys as key>
@@ -139,7 +139,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
         </select>
     </p>
         <p>
-            <label for="title">${i18n().title_capitalized} ${requiredHint}</label>
+            <label for="title"  class="inline">${i18n().title_capitalized} ${requiredHint}</label>
             <input class="acSelector" size="60"  type="text" id="title" name="title" acGroupName="publication"  value="${titleValue}" />
         </p>
 

--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage_fr_CA.ftl
@@ -130,8 +130,16 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
     <form id="add${roleDescriptor?cap_first}RoleToPersonTwoStage" class="customForm noIE67" action="${submitUrl}"  role="add/edit grant role">
 
-       <p class="inline">
-        <label for="typeSelector">${typeSelectorLabel?cap_first}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
+            <#if showRoleLabelField = true>
+            <p><label for="roleLabel" class="inline">${i18n().user_role} ${roleExamples}</label>
+                <input  size="50"  type="text" id="roleLabel" name="roleLabel" value="${roleLabel}" />
+            </p>
+        	</#if>
+
+	  <h3>${genericLabel?cap_first}</h3>
+
+       <p>
+        <label for="typeSelector" class="inline">${i18n().type_capitalized?cap_first}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
         <#--Code below allows for selection of first 'select one' option if no activity type selected-->
         <#if activityTypeValue?has_content>
         	<#assign selectedActivityType = activityTypeValue />
@@ -163,7 +171,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 		Adaptation of structure for french 
  -->
             <p>
-                <label for="activity">${i18n().name_of?cap_first} l'${genericLabel?lower_case}  ${requiredHint}</label>
+                <label for="activity" class="inline">${i18n().name?cap_first} ${requiredHint}</label>
                 <input class="acSelector" size="50"  type="text" id="activity" name="activityLabel"  acGroupName="activity" value="${activityLabelValue}" />
                 <input class="display" type="hidden" id="activityDisplay" acGroupName="activity" name="activityLabelDisplay" value="${activityLabelDisplayValue}">
             </p>
@@ -183,12 +191,6 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
                     <!-- Field value populated by JavaScript -->
             </div>
 
-            <#if showRoleLabelField = true>
-            <p><label for="roleLabel">${i18n().role_in} l'${genericLabel?lower_case} ${roleExamples}</label>
-                <input  size="50"  type="text" id="roleLabel" name="roleLabel" value="${roleLabel}" />
-            </p>
-        	</#if>
-
             <#if numDateFields == 1 >
                <#--Generated html is a map with key name mapping to html string-->
                <#if htmlForElements?keys?seq_contains("startField")>
@@ -196,12 +198,12 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
                		${htmlForElements["startField"]} ${yearHint}
                </#if>
             <#else>
-                <h4 class="label">${i18n().years_participating} </h4>
+                <h3 class="label">${i18n().years_participating} </h3>
                 <#if htmlForElements?keys?seq_contains("startField")>
                 	    <label class="dateTime" for="startField">${i18n().start_year}</label>
                		    ${htmlForElements["startField"]} ${yearHint}
                </#if>
-               <p></p>
+               <br/>
                <#if htmlForElements?keys?seq_contains("endField")>
                		    <label class="dateTime" for="endField">${i18n().end_year}</label>
                		    ${htmlForElements["endField"]} ${yearHint}

--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteObjectPropForm_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/autoCompleteObjectPropForm_fr_CA.ftl
@@ -58,7 +58,7 @@
 
             <#---This section should become autocomplete instead-->
             <p>
-				<label for="object">  ${i18n().name_capitalized?cap_first} de la ${propertyNameForDisplay?lower_case} <span class='requiredHint'> *</span></label>
+				<label for="object" class="inline">${i18n().name_capitalized?cap_first}<span class='requiredHint'> *</span></label>
 				<input class="acSelector" size="50"  type="text" id="object" name="objectLabel" acGroupName="object" value="${objectLabel}" />
 			</p>
 

--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasEducationalTraining_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/personHasEducationalTraining_fr_CA.ftl
@@ -110,9 +110,9 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
     <form id="personHasEducationalTraining" class="customForm noIE67" action="${submitUrl}"  role="add/edit educational training">
 
-
-    <p class="inline">
-        <label for="orgType">${i18n().org_type_capitalized} ${requiredHint}</label>
+	<h3>${i18n().organization_capitalized}</h3>
+    <p>
+        <label for="orgType"  class="inline">${i18n().type_capitalized?cap_first} ${requiredHint}</label>
         <#assign orgTypeOpts = editConfiguration.pageData.orgType />
         <select id="typeSelector" name="orgType" acGroupName="organization">
             <option value="" selected="selected">${i18n().select_one}</option>
@@ -127,14 +127,14 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     </p>
 
     <p>
-        <label for="relatedIndLabel">${i18n().organization_capitalized} ${i18n().name_capitalized} ${requiredHint}</label>
+        <label for="relatedIndLabel" class="inline">${i18n().name_capitalized} ${requiredHint}</label>
         <input class="acSelector" size="50"  type="text" id="relatedIndLabel" name="orgLabel" acGroupName="organization" value="${orgLabelValue}"  />
         <input class="display" type="hidden" id="orgDisplay" acGroupName="organization" name="orgLabelDisplay" value="${orgLabelDisplayValue}">
     </p>
 
     <div class="acSelection" acGroupName="organization">
-        <p class="inline">
-            <label>${i18n().selected_organization}:</label>
+        <p>
+            <label class="inline">${i18n().selected_organization}:</label>
             <span class="acSelectionInfo"></span>
             <a href="" class="verifyMatch"  title="${i18n().verify_match_capitalized}">(${i18n().verify_match_capitalized}</a> ${i18n().or}
             <a href="#" class="changeSelection" id="changeSelection">${i18n().change_selection})</a>
@@ -142,7 +142,13 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
         <input class="acUriReceiver" type="hidden" id="orgUri" name="existingOrg" value="${existingOrgValue}" ${flagClearLabelForExisting}="true" />
     </div>
 
-    <label for="positionType">${i18n().educational_training_type} ${requiredHint}</label>
+    <p>
+        <label for="dept"  class="inline">${i18n().dept_or_school_name} ${i18n().organization_capitalized}</label>
+        <input  size="50"  type="text" id="dept" name="dept" value="${deptValue}" />
+    </p>
+    
+    <h3>${i18n().educational_training?cap_first}</h3>
+    <label for="positionType" class="inline">${i18n().type_capitalized?cap_first} ${requiredHint}</label>
     <#assign trainingTypeOpts = editConfiguration.pageData.trainingType />
     <select name="trainingType" style="margin-top:-2px" >
         <option value="" <#if trainingTypeValue == "">selected</#if>>${i18n().select_one}</option>
@@ -150,13 +156,9 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
             <option value="${key}"  <#if trainingTypeValue == key>selected</#if>><#if trainingTypeOpts[key] == "Other">${i18n().academic_studies_or_other}<#else>${trainingTypeOpts[key]}</#if></option>
         </#list>
     </select>
-    <p>
-        <label for="dept">${i18n().dept_or_school_name} ${i18n().organization_capitalized}</label>
-        <input  size="50"  type="text" id="dept" name="dept" value="${deptValue}" />
-    </p>
 
     <div class="entry">
-      <label for="degreeUri">${i18n().degree}</label>
+      <label for="degreeUri" class="inline">${i18n().degree}</label>
 
       <#assign degreeOpts = editConfiguration.pageData.degreeType />
       <select name="degreeType" id="degreeUri" >
@@ -177,24 +179,24 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
     </div>
 
     <p>
-        <label for="majorField">${i18n().major_field}</label>
+        <label for="majorField" class="inline">${i18n().major_field}</label>
         <input type="text" id="majorField" name="majorField" size="30" value="${majorFieldValue}"/>
     </p>
 
     <p>
-        <label for="info">${i18n().supplemental_information}
+        <label for="info" class="inline">${i18n().supplemental_information}
             <span class="hint">&nbsp;${i18n().supplemental_information_hint}</span>
         </label>
         <input  size="60"  type="text" id="info" name="info" value="${infoValue}" />
 
     </p>
-    <p></p>
+    <br/>
     <#--Need to draw edit elements for dates here-->
      <#if htmlForElements?keys?seq_contains("startField")>
 			<label class="dateTime" for="startField">${i18n().start_capitalized}</label>
 			${htmlForElements["startField"]} ${yearHint}
      </#if>
-     <p></p>
+     <br/>
      <#if htmlForElements?keys?seq_contains("endField")>
 			<label class="dateTime" for="endField">${i18n().end_capitalized}</label>
 		 	${htmlForElements["endField"]} ${yearHint}

--- a/fr_CA/webapp/src/main/webapp/themes/tenderfoot/i18n/all_fr_CA.properties
+++ b/fr_CA/webapp/src/main/webapp/themes/tenderfoot/i18n/all_fr_CA.properties
@@ -52,7 +52,7 @@ grant_date = date de la subvention
 loading_data = chargement des données
 to = à
 collection_capitalized = Collection
-collection_or_series = la collection ou la série
+collection_or_series = collection ou série
 
 create_entry = Créer un enregistrement
 first_grant = Première subvention

--- a/fr_CA/webapp/src/main/webapp/themes/wilma/i18n/all_fr_CA.properties
+++ b/fr_CA/webapp/src/main/webapp/themes/wilma/i18n/all_fr_CA.properties
@@ -25,7 +25,7 @@ identity_myaccount = Mon compte
 identity_user = utilisateur(-trice)
 
 collection_capitalized = Collection
-collection_or_series = la collection ou la série
+collection_or_series = collection ou série
 place_of_grant = Lieu de la subvention
 email_address = Courriel
 


### PR DESCRIPTION
Better alternative to :
https://github.com/vivo-project/VIVO-languages/pull/42

Resolves : 
[https://jira.lyrasis.org/browse/VIVO-1796](https://jira.lyrasis.org/browse/VIVO-1796)
[https://jira.lyrasis.org/browse/VIVO-1797](https://jira.lyrasis.org/browse/VIVO-1797)
[https://jira.lyrasis.org/browse/VIVO-1818](https://jira.lyrasis.org/browse/VIVO-1818)

### What does this pull request do?
The systematic concatenation of variables in the .ftl files creates several grammar and syntax problems across different languages. 

This pull request aims at minimizing the use of concatenated labels in order to fix those problems in the French version, using an approach that could possibily be generalized in the core .ftl files to improve their reusability _as-is_ across languages. 

In order to achieve this goal, related fields have been grouped and headed (`h3`) by redundant/common strings removed from the labels. This approach allows for maximal reuse of variables and strings already present in the .ftl and .properties files, with two exceptions: 
-  The string `dept_or_school_name `had to be added to [vivo_all_fr_CA.properties](https://github.com/vivo-project/VIVO-languages/blob/sprint-i18n/fr_CA/webapp/src/main/webapp/i18n/vivo_all_fr_CA.properties/vivo-languages-webapp-fr_CA/src/main/webapp/i18n/vivo_all_fr_CA.properties).
-  The string `collection_or_series `had to be modified in various .properties files.

Some formal changes were made to improve organization and readability :
* Some field have been relocated to allow regrouping
* In somes cases, `<h4>` headers have been converted to `<h3>` header to improve readability.
* Several labels were aligned with the input fields for a more compact layout. Whenever the `class="inline"` was placed within a `<p>` tag, it was relocated in the daughter `<label>` tag, as the basic edit.css stylesheets specify a layout for `label.inline`, but not for `p.inline`. There is a `p.inline` statement in customForm.css, but it was not having the desired effect.

Unrelated but minor changes:
* In a few cases, `<p></p>` have been replaced by `<br/>`

**Note:** this pull request only fixes the most problematic cases. Another pull request should aim at fine tuning the normalization of forms across the whole site, making sure the layout is always consistant (e.g. should the input field be always inline with the label, etc) 

### How should this be tested?

- Add and Edit forms should be tested for the following sections:
   - Direction de
   - Membre de
   - Activités cliniques
   - Événements
   - Publications choisies
   - Responsable de collection
   - Éditeur
   - Autres activités de recherche
   - Activités d'enseignement
   - Évaluateur(-trice))
   - Organisateur d'événement
   - Activités professionnelles
   - Mobilisation des connaissances
   - Enseignement et formation
   - Lieu

### Interested parties

@MichelHeon 