### PR TITLE
Changed/inserted variables in .ftl files to fix French syntax problems

### DIFF
--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addPresenterRoleToPerson_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addPresenterRoleToPerson_fr_CA.ftl
@@ -117,7 +117,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
     <div class="acSelection" acGroupName="presentation">
         <p class="inline">
-            <label>${i18n().selected_presentation}:</label>
+            <label>${i18n().selected}:</label>
             <span class="acSelectionInfo"></span>
             <a href="" class="verifyMatch"  title="${i18n().verify_match_capitalized}">(${i18n().verify_match_capitalized}</a> ${i18n().or}
             <a href="#" class="changeSelection" id="changeSelection">${i18n().change_selection})</a>

--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage_fr_CA.ftl
@@ -173,7 +173,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
             <div class="acSelection" acGroupName="activity">
                 <p class="inline">
-                    <label></label>
+                    <label>${i18n().selected}:</label>
                     <span class="acSelectionInfo"></span>
                     <a href="/vivo/individual?uri=" class="verifyMatch" title="${i18n().verify_match_capitalized}">(${i18n().verify_match_capitalized}</a> ${i18n().or}
                     <a href="#" class="changeSelection" id="changeSelection">${i18n().change_selection})</a>


### PR DESCRIPTION
Resolves : 
[https://jira.lyrasis.org/browse/VIVO-1773](https://jira.lyrasis.org/browse/VIVO-1773)

Related PR : https://github.com/vivo-project/Vitro-languages/pull/19

### What does this pull request do?
* Some English strings are pulled into French form [addRoleToPersonTwoStage_fr_CA.ftl](https://github.com/vivo-project/VIVO-languages/blob/sprint-i18n/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage_fr_CA.ftl) files through [customFormWithAutocomplete.js](https://github.com/vivo-project/VIVO-languages/blob/sprint-i18n/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/js/customFormWithAutocomplete.js) (line 512)
* Instead of relying on said script, I replicated a method used in other .ftl forms and inserted a preexisting variable that pulls a string from [all_fr_CA.properties](https://github.com/vivo-project/Vitro-languages/blob/sprint-i18n/fr_CA/webapp/src/main/webapp/i18n/all_fr_CA.properties).
* However, said string had to be slightly edited (see https://github.com/vivo-project/Vitro-languages/pull/19)

### How should this be tested?

* All edit forms using `addRoleToPersonTwoStage_fr_CA.ftl` should be tested :
   - Direction de
   - Membre de
   - Activités cliniques
   - Événements
   - Responsable de collection
   - Autres activités de recherche
   - Activités d'enseignement
   - Évaluateur(-trice))
   - Organisateur d'événement
   - Activités professionnelles
   - Mobilisation des connaissances
   - Enseignement et formation

* Related modifications in other .ftl files have to be tested in following edit forms:
   - Collaborateur(-trice) 
   - Mentionné dans
   - Lieu
   
### Interested parties

@MichelHeon 