### PR TITLE
i18n: title tag and headings in capability map are in english in french version

### DIFF
--- a/de_DE/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
+++ b/de_DE/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
@@ -906,3 +906,5 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
+
+term_capitalized = Begriff

--- a/de_DE/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_de_DE.ftl
+++ b/de_DE/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_de_DE.ftl
@@ -15,8 +15,13 @@ ${stylesheets.add(
 )}
 
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
+        document.title = "Capability Map";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/en_CA/webapp/src/main/webapp/i18n/vivo_all_en_CA.properties
+++ b/en_CA/webapp/src/main/webapp/i18n/vivo_all_en_CA.properties
@@ -906,3 +906,5 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
+
+term_capitalized = Term

--- a/en_CA/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_en_CA.ftl
+++ b/en_CA/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_en_CA.ftl
@@ -15,8 +15,13 @@ ${stylesheets.add(
 )}
 
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
+        document.title = "Capability Map";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/en_US/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
+++ b/en_US/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
@@ -906,3 +906,5 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
+
+term_capitalized = Term

--- a/en_US/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_en_US.ftl
+++ b/en_US/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_en_US.ftl
@@ -14,9 +14,15 @@ ${stylesheets.add(
     '<link rel="stylesheet" type="text/css" href="${urls.base}/css/visualization/capabilitymap/graph.css" />'
 )}
 
+
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
+        document.title = "Capability Map";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/es/webapp/src/main/webapp/i18n/vivo_all_es.properties
+++ b/es/webapp/src/main/webapp/i18n/vivo_all_es.properties
@@ -908,3 +908,5 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
+
+term_capitalized = Término

--- a/es/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_es.ftl
+++ b/es/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_es.ftl
@@ -15,8 +15,13 @@ ${stylesheets.add(
 )}
 
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
+        document.title = "Mapa de capacidades";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/fr_CA/webapp/src/main/webapp/i18n/vivo_all_fr_CA.properties
+++ b/fr_CA/webapp/src/main/webapp/i18n/vivo_all_fr_CA.properties
@@ -908,3 +908,5 @@ create_and_link_type_webpage=Page web
 claim_publications_by=Publications revendiquées par 
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=Identifiant PubMed
+
+term_capitalized = Terme

--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_fr_CA.ftl
@@ -15,8 +15,13 @@ ${stylesheets.add(
 )}
 
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
+        document.title = "Cartographie d'expertises";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/pt_BR/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
+++ b/pt_BR/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
@@ -907,3 +907,5 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
+
+term_capitalized = Termo

--- a/pt_BR/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_pt_BR.ftl
+++ b/pt_BR/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_pt_BR.ftl
@@ -15,8 +15,13 @@ ${stylesheets.add(
 )}
 
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
+        document.title = "Mapa de Capacidade";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",


### PR DESCRIPTION
I added the multi-language term and support for a part of the capability map
[JIRA Ticket](https://jira.lyrasis.org/browse/VIVO-1847) 

but not just for fr_CA, i did it for every language in der VIVO-language Repository.

for description see [PR in VIVO Repo](https://github.com/vivo-project/VIVO/pull/172)