### PR TITLE
i18n: title tag and headings in capability map are in english in french version

### DIFF
--- a/de_DE/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
+++ b/de_DE/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
@@ -580,7 +580,7 @@ vis_caching_process = Was beinhaltet der Vorgang zur Zwischenspeicherung?
 vis_tools_note_two = Zu diesem Zweck haben wir eine Zwischenspeicherungslösung entwickelt, die durch die Speicherung des RDF-Modells Informationen über die Hierarchie der Organisationen speichert -- d. h. welche Publikationen welchen Organisationen zugerechnet werden.
 vis_tools_note_three = Zurzeit speichern wir diese Modelle im Hauptspeicherbereich zwischen. Der Zwischenspeicher wird (nur einmal) bei der ersten Benutzeranfrage nach einem Neustart des Servers aufgebaut. Daher wird bis zum nächsten Neustart das gleiche Modell bedient. Das bedeutet, dass die Daten in den Modellen veralten können, je nachdem, wann das Modell zum letzten Mal erstellt wurde. Das funktioniert fürs Erste gut. In kommenden Releases werden wir diese Lösung dahingehend verbessern, dass Modelle auf Festplatte gespeichert und regelmäßig aktualisiert werden.
 vis_tools_note_four = Die Modelle werden bei jedem Neustart des Servers aktualisiert. Da dies auf der Produktionsinstanz  allgemein unpraktisch ist, können AdministratorInnen stattdessen den “Zwischenspeicher aktualisieren”-Link oben verwenden, um ohne einen Neustart eine Aktualisierung durchzuführen.
-capability_map=Capability Map
+capability_map=Forschungsnetz
 term_capitalized=Begriff
 
 #

--- a/de_DE/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
+++ b/de_DE/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
@@ -906,3 +906,5 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
+
+term_capitalized = Begriff

--- a/de_DE/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
+++ b/de_DE/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
@@ -580,6 +580,8 @@ vis_caching_process = Was beinhaltet der Vorgang zur Zwischenspeicherung?
 vis_tools_note_two = Zu diesem Zweck haben wir eine Zwischenspeicherungslösung entwickelt, die durch die Speicherung des RDF-Modells Informationen über die Hierarchie der Organisationen speichert -- d. h. welche Publikationen welchen Organisationen zugerechnet werden.
 vis_tools_note_three = Zurzeit speichern wir diese Modelle im Hauptspeicherbereich zwischen. Der Zwischenspeicher wird (nur einmal) bei der ersten Benutzeranfrage nach einem Neustart des Servers aufgebaut. Daher wird bis zum nächsten Neustart das gleiche Modell bedient. Das bedeutet, dass die Daten in den Modellen veralten können, je nachdem, wann das Modell zum letzten Mal erstellt wurde. Das funktioniert fürs Erste gut. In kommenden Releases werden wir diese Lösung dahingehend verbessern, dass Modelle auf Festplatte gespeichert und regelmäßig aktualisiert werden.
 vis_tools_note_four = Die Modelle werden bei jedem Neustart des Servers aktualisiert. Da dies auf der Produktionsinstanz  allgemein unpraktisch ist, können AdministratorInnen stattdessen den “Zwischenspeicher aktualisieren”-Link oben verwenden, um ohne einen Neustart eine Aktualisierung durchzuführen.
+capability_map=Capability Map
+term_capitalized=Begriff
 
 #
 #  custom form javascript variables ( /templates/freemarker/edit/js)
@@ -906,5 +908,3 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
-
-term_capitalized = Begriff

--- a/de_DE/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_de_DE.ftl
+++ b/de_DE/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_de_DE.ftl
@@ -38,7 +38,7 @@ ${stylesheets.add(
 </script>
 <div class="main" id="main-content" role="main">
     <div class="col-8">
-        <h2>Capability Map</h2>
+        <h2>Forschungsnetz</h2>
 		<p>Erstellen Sie eine Capability Map durch Eingabe von Suchbegriffen.</p>       
     </div>
 

--- a/de_DE/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_de_DE.ftl
+++ b/de_DE/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_de_DE.ftl
@@ -15,8 +15,13 @@ ${stylesheets.add(
 )}
 
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
+        document.title = "Capability Map";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/de_DE/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_de_DE.ftl
+++ b/de_DE/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_de_DE.ftl
@@ -16,12 +16,12 @@ ${stylesheets.add(
 
 <script language="JavaScript" type="text/javascript">
     var i18nStringsCap = {
-        term: '${i18n().group_capitalized}',
-        group: '${i18n().term_capitalized}'
+        term: '${i18n().term_capitalized}',
+        group: '${i18n().group_capitalized}'
     };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
-        document.title = "Capability Map";
+        document.title = "${i18n().capability_map}";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/en_CA/webapp/src/main/webapp/i18n/vivo_all_en_CA.properties
+++ b/en_CA/webapp/src/main/webapp/i18n/vivo_all_en_CA.properties
@@ -580,6 +580,8 @@ vis_caching_process = What's involved in the caching process?
 vis_tools_note_two = To this end we have devised a caching solution which will retain information about the hierarchy of organizations -- namely, which publications are attributed to which organizations -- by storing the RDF model.
 vis_tools_note_three = We're currently caching these models in memory.  The cache is built (only once) on the first user request after a server restart.  Because of this, the same model will be served until the next restart. This means that the data in these models may become stale depending upon when it was last created. This works well enough for now. In future releases we will improve this solution so that models are stored on disk and periodically updated.
 vis_tools_note_four = The models are refreshed each time the server restarts.  Since this is not generally practical on production instances, administrators can instead use the "refresh cache" link above to do this without a restart.
+capability_map=Capability Map
+term_capitalized=Term
 
 #
 #  custom form javascript variables ( /templates/freemarker/edit/js)
@@ -906,5 +908,3 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
-
-term_capitalized = Term

--- a/en_CA/webapp/src/main/webapp/i18n/vivo_all_en_CA.properties
+++ b/en_CA/webapp/src/main/webapp/i18n/vivo_all_en_CA.properties
@@ -906,3 +906,5 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
+
+term_capitalized = Term

--- a/en_CA/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_en_CA.ftl
+++ b/en_CA/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_en_CA.ftl
@@ -15,8 +15,13 @@ ${stylesheets.add(
 )}
 
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
+        document.title = "Capability Map";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/en_CA/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_en_CA.ftl
+++ b/en_CA/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_en_CA.ftl
@@ -16,12 +16,12 @@ ${stylesheets.add(
 
 <script language="JavaScript" type="text/javascript">
     var i18nStringsCap = {
-        term: '${i18n().group_capitalized}',
-        group: '${i18n().term_capitalized}'
+        term: '${i18n().term_capitalized}',
+        group: '${i18n().group_capitalized}'
     };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
-        document.title = "Capability Map";
+        document.title = "${i18n().capability_map}";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/en_US/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
+++ b/en_US/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
@@ -580,6 +580,8 @@ vis_caching_process = What's involved in the caching process?
 vis_tools_note_two = To this end we have devised a caching solution which will retain information about the hierarchy of organizations -- namely, which publications are attributed to which organizations -- by storing the RDF model.
 vis_tools_note_three = We're currently caching these models in memory.  The cache is built (only once) on the first user request after a server restart.  Because of this, the same model will be served until the next restart. This means that the data in these models may become stale depending upon when it was last created. This works well enough for now. In future releases we will improve this solution so that models are stored on disk and periodically updated.
 vis_tools_note_four = The models are refreshed each time the server restarts.  Since this is not generally practical on production instances, administrators can instead use the "refresh cache" link above to do this without a restart.
+capability_map=Capability Map
+term_capitalized=Term
 
 #
 #  custom form javascript variables ( /templates/freemarker/edit/js)
@@ -906,5 +908,3 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
-
-term_capitalized = Term

--- a/en_US/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
+++ b/en_US/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
@@ -906,3 +906,5 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
+
+term_capitalized = Term

--- a/en_US/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_en_US.ftl
+++ b/en_US/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_en_US.ftl
@@ -14,9 +14,15 @@ ${stylesheets.add(
     '<link rel="stylesheet" type="text/css" href="${urls.base}/css/visualization/capabilitymap/graph.css" />'
 )}
 
+
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
+        document.title = "Capability Map";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/en_US/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_en_US.ftl
+++ b/en_US/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_en_US.ftl
@@ -17,12 +17,12 @@ ${stylesheets.add(
 
 <script language="JavaScript" type="text/javascript">
     var i18nStringsCap = {
-        term: '${i18n().group_capitalized}',
-        group: '${i18n().term_capitalized}'
+        term: '${i18n().term_capitalized}',
+        group: '${i18n().group_capitalized}'
     };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
-        document.title = "Capability Map";
+        document.title = "${i18n().capability_map}";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/es/webapp/src/main/webapp/i18n/vivo_all_es.properties
+++ b/es/webapp/src/main/webapp/i18n/vivo_all_es.properties
@@ -592,6 +592,8 @@ vis_caching_process = ¿Qué implica el proceso de almacenamiento en caché?
 vis_tools_note_two = Para ello hemos diseñado una solución de almacenamiento en caché que mantendrá información sobre la jerarquía de las organizaciones - a saber,que publicaciones están asociadas a que organizaciones - almacenando el modelo RDF.
 vis_tools_note_three = Actualmente el cache de estos modelos estan en la memoria. La caché se construye (sólo una vez) en la primera solicitud de un usuario después de un reinicio del servidor. Debido a esto, el mismo modelo sirve hasta el siguiente reinicio. Esto significa que los datos de estos modelos pueden convertirse en obsoletos dependiendo de cuando fueron creados. Esto funciona bastante bien por ahora. En futuras versiones, mejoraremos esta solución para que los modelos se almacenan en el disco y se actualizan periódicamente.
 vis_tools_note_four = Los modelos se actualizan cada vez que se reinicia el servidor. Dado que esto no es generalmente práctico sobre instancias de producción, los administradores pueden usar el enlace "actualización de caché" para hacer esto sin reiniciar.
+capability_map=Mapa de capacidades
+term_capitalized=Término
 
 #
 #  variables de javascript en formularios personalizados ( /templates/freemarker/edit/js)
@@ -908,5 +910,3 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
-
-term_capitalized = Término

--- a/es/webapp/src/main/webapp/i18n/vivo_all_es.properties
+++ b/es/webapp/src/main/webapp/i18n/vivo_all_es.properties
@@ -908,3 +908,5 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
+
+term_capitalized = Término

--- a/es/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_es.ftl
+++ b/es/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_es.ftl
@@ -16,12 +16,12 @@ ${stylesheets.add(
 
 <script language="JavaScript" type="text/javascript">
     var i18nStringsCap = {
-        term: '${i18n().group_capitalized}',
-        group: '${i18n().term_capitalized}'
+        term: '${i18n().term_capitalized}',
+        group: '${i18n().group_capitalized}'
     };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
-        document.title = "Mapa de capacidades";
+        document.title = "${i18n().capability_map}";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/es/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_es.ftl
+++ b/es/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_es.ftl
@@ -15,8 +15,13 @@ ${stylesheets.add(
 )}
 
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
+        document.title = "Mapa de capacidades";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/fr_CA/webapp/src/main/webapp/i18n/vivo_all_fr_CA.properties
+++ b/fr_CA/webapp/src/main/webapp/i18n/vivo_all_fr_CA.properties
@@ -582,6 +582,8 @@ vis_caching_process = Qu'est-ce qui est impliqué dans le processus de mise en c
 vis_tools_note_two = À cette fin, nous avons conçu une solution de mise en mémoire cache qui conservera les informations sur la hiérarchie des organisations - à savoir, quelles publications sont attribuées à quelles organisations - en stockant le modèle RDF.
 vis_tools_note_three = Nous sommes en train de mettre ces modèles en mémoire cache. Le cache est construit (une seule fois) à la première demande de l'utilisateur après un redémarrage du serveur.  Pour cette raison, le même modèle sera servi jusqu'au prochain redémarrage. Cela signifie que les données de ces modèles peuvent devenir périmées selon la date de leur dernière création. Cela fonctionne assez bien pour l'instant. Dans les prochaines versions, nous améliorerons cette solution afin que les modèles soient stockés sur disque et mis à jour périodiquement.
 vis_tools_note_four = Les modèles sont actualisés chaque fois que le serveur redémarre. Comme ce n'est généralement pas pratique sur les instances de production, les administrateurs peuvent utiliser le lien "rafraîchir le cache" ci-dessus pour le faire sans redémarrer.
+capability_map=Cartographie d'expertises
+term_capitalized=Terme
 
 #
 #  custom form javascript variables ( /templates/freemarker/edit/js)
@@ -908,5 +910,3 @@ create_and_link_type_webpage=Page web
 claim_publications_by=Publications revendiquées par 
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=Identifiant PubMed
-
-term_capitalized = Terme

--- a/fr_CA/webapp/src/main/webapp/i18n/vivo_all_fr_CA.properties
+++ b/fr_CA/webapp/src/main/webapp/i18n/vivo_all_fr_CA.properties
@@ -908,3 +908,5 @@ create_and_link_type_webpage=Page web
 claim_publications_by=Publications revendiquées par 
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=Identifiant PubMed
+
+term_capitalized = Terme

--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_fr_CA.ftl
@@ -16,12 +16,12 @@ ${stylesheets.add(
 
 <script language="JavaScript" type="text/javascript">
     var i18nStringsCap = {
-        term: '${i18n().group_capitalized}',
-        group: '${i18n().term_capitalized}'
+        term: '${i18n().term_capitalized}',
+        group: '${i18n().group_capitalized}'
     };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
-        document.title = "Cartographie d'expertises";
+        document.title = "${i18n().capability_map}";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_fr_CA.ftl
@@ -15,8 +15,13 @@ ${stylesheets.add(
 )}
 
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
+        document.title = "Cartographie d'expertises";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/pt_BR/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
+++ b/pt_BR/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
@@ -907,3 +907,5 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
+
+term_capitalized = Termo

--- a/pt_BR/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
+++ b/pt_BR/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
@@ -590,6 +590,8 @@ vis_caching_process = O que está envolvido no processo de armazenamento em cach
 vis_tools_note_two = Para este fim, criaram uma solução de cache que irá reter informações sobre a hierarquia das organizações - a saber, que as publicações são atribuídos a que as organizações - por armazenar o modelo RDF.
 vis_tools_note_three = No momento, estamos cache esses modelos na memória. O cache é construído (apenas uma vez) na primeira solicitação do usuário após a reinicialização do servidor. Devido a isso, o mesmo modelo será servido até a próxima reinicialização. Isto significa que os dados nestes modelos pode tornar-se obsoleto dependendo de quando foi criado último. Isso funciona bem o suficiente para agora. Em versões futuras, vamos melhorar esta solução para que os modelos são armazenados no disco e periodicamente atualizado.
 vis_tools_note_four = Os modelos são atualizadas a cada vez que o servidor for reiniciado. Uma vez que este não é geralmente prático sobre instâncias de produção, os administradores podem passar a usar o link "cache refresh" acima de fazer isso sem uma reinicialização.
+capability_map=Mapa de Capacidade
+term_capitalized=Termo
 
 #
 #  custom form javascript variables ( /templates/freemarker/edit/js)
@@ -907,5 +909,3 @@ create_and_link_type_webpage=Webpage
 claim_publications_by=Claim publications by
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=PubMed ID
-
-term_capitalized = Termo

--- a/pt_BR/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_pt_BR.ftl
+++ b/pt_BR/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_pt_BR.ftl
@@ -15,8 +15,13 @@ ${stylesheets.add(
 )}
 
 <script language="JavaScript" type="text/javascript">
+    var i18nStringsCap = {
+        term: '${i18n().group_capitalized}',
+        group: '${i18n().term_capitalized}'
+    };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
+        document.title = "Mapa de Capacidade";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",

--- a/pt_BR/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_pt_BR.ftl
+++ b/pt_BR/webapp/src/main/webapp/templates/freemarker/visualization/capabilitymap/capabilityMap_pt_BR.ftl
@@ -16,12 +16,12 @@ ${stylesheets.add(
 
 <script language="JavaScript" type="text/javascript">
     var i18nStringsCap = {
-        term: '${i18n().group_capitalized}',
-        group: '${i18n().term_capitalized}'
+        term: '${i18n().term_capitalized}',
+        group: '${i18n().group_capitalized}'
     };
     var contextPath = "${urls.base}";
     $(document).ready(function() {
-        document.title = "Mapa de Capacidade";
+        document.title = "${i18n().capability_map}";
         var loadedConcepts = $.ajax({
             url: contextPath + "/visualizationAjax?vis=capabilitymap&data=concepts",
             type: "GET",


### PR DESCRIPTION
I added the multi-language terms and support for a part of the capability map
[JIRA Ticket](https://jira.lyrasis.org/browse/VIVO-1847) 

but not just for fr_CA, i did it for every language in der VIVO-language Repository.

for description see [PR in VIVO Repo](https://github.com/vivo-project/VIVO/pull/173)