### PR TITLE
 Added properties for labelling former key.png in cap map.

### DIFF
--- a/de_DE/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
+++ b/de_DE/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
@@ -612,7 +612,12 @@ cap_map_info=Info
 cap_map_cur_search_terms=Aktuelle Suchbegriffe
 cap_map_text6=Dieses Fenster zeigt eine Liste der Suchbegriffe an, die sich derzeit in der Grafik befinden. Um zu beginnen, bitte nach etwas suchen.
 cap_map_text7=Dieses Fenster zeigt Informationen über einzelne Suchbegriffe und Gruppen an. Klicken Sie auf eine Gruppe, um Informationen über sie anzuzeigen.
-
+cap_map_key1=Fähigkeit
+cap_map_key2=Verbindung
+cap_map_key3=Gruppe
+cap_map_key4=2 Verbindungen
+cap_map_key5=3 Verbindungen
+cap_map_key6=>=4 Verbindungen
 
 #
 #  custom form javascript variables ( /templates/freemarker/edit/js)

--- a/en_CA/webapp/src/main/webapp/i18n/vivo_all_en_CA.properties
+++ b/en_CA/webapp/src/main/webapp/i18n/vivo_all_en_CA.properties
@@ -612,6 +612,12 @@ cap_map_info=Info
 cap_map_cur_search_terms=Current search terms
 cap_map_text6=This panel displays a list of the search terms currently on the graph. Search for something to begin.
 cap_map_text7=This panel displays information about individual search terms and groups. Click on a group to display its information.
+cap_map_key1=capability
+cap_map_key2=link
+cap_map_key3=group
+cap_map_key4=2 links
+cap_map_key5=3 links
+cap_map_key6=>=4 links
 
 #
 #  custom form javascript variables ( /templates/freemarker/edit/js)

--- a/en_US/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
+++ b/en_US/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
@@ -612,7 +612,12 @@ cap_map_info=Info
 cap_map_cur_search_terms=Current search terms
 cap_map_text6=This panel displays a list of the search terms currently on the graph. Search for something to begin.
 cap_map_text7=This panel displays information about individual search terms and groups. Click on a group to display its information.
-
+cap_map_key1=capability
+cap_map_key2=link
+cap_map_key3=group
+cap_map_key4=2 links
+cap_map_key5=3 links
+cap_map_key6=>=4 links
 
 #
 #  custom form javascript variables ( /templates/freemarker/edit/js)

--- a/es/webapp/src/main/webapp/i18n/vivo_all_es.properties
+++ b/es/webapp/src/main/webapp/i18n/vivo_all_es.properties
@@ -624,7 +624,12 @@ cap_map_info=Información
 cap_map_cur_search_terms=Términos de búsqueda actuales
 cap_map_text6=Este panel muestra una lista de los términos de búsqueda actualmente en el gráfico. Busque algo para comenzar.
 cap_map_text7=Este panel muestra información sobre el individuo términos y grupos de búsqueda. Haga clic en un grupo para mostrar su información.
-
+cap_map_key1=capacidad
+cap_map_key2=enlace
+cap_map_key3=grupo
+cap_map_key4=2 enlaces
+cap_map_key5=3 enlaces
+cap_map_key6=>= 4 enlaces
 
 #
 #  variables de javascript en formularios personalizados ( /templates/freemarker/edit/js)

--- a/fr_CA/webapp/src/main/webapp/i18n/vivo_all_fr_CA.properties
+++ b/fr_CA/webapp/src/main/webapp/i18n/vivo_all_fr_CA.properties
@@ -74,7 +74,7 @@ advisingRel_label = étiquette de rôle conseil
 editor_abbreviated = Éd.
 volume_abbreviated = Vol.
 resource_name = nom de la ressource
-missing_info_resource = Information manquante sur la ressource 
+missing_info_resource = Information manquante sur la ressource
 
 award_receipt_name = Récipiendaire du prix
 award_name = Nom du prix
@@ -306,8 +306,8 @@ selected_book = Livre choisi
 publication_date = Date de publication
 place_of_publication = Lieu de publication
 
-research_activity = activité de recherche: 
-research_activity_type = type d'activité de recherche: 
+research_activity = activité de recherche:
+research_activity_type = type d'activité de recherche:
 
 reviewer_of = réviseur de
 
@@ -350,7 +350,7 @@ new_local_ontology = nouvelle ontologie locale
 manage_grants_and_projects = Gérer les subventions et les projets pour
 check_grants_to_exclude = Choisir les subventions et projets que vous désirez <em>exclure</em> de votre profil.
 
-manage_affiliated_people = Gérer les affiliations des personnes à 
+manage_affiliated_people = Gérer les affiliations des personnes à
 check_people_to_exclude = Choisir les personnes que vous désirez <em>exclure</em> de la page des profils.
 
 manage_publications_for = Gestion des publications pour
@@ -363,7 +363,7 @@ delete_webpage_link = Supprimer le lien vers la page web
 webpage_url = URL de la page web
 add_new_web_page = Ajouter une nouvelle page web
 
-enable_internal_class_one = Pour activer cette option vous devez d'abord choisir un 
+enable_internal_class_one = Pour activer cette option vous devez d'abord choisir un
 enable_internal_class_two = pour votre instance
 internal_class = classe interne institutionnelle
 only_display = Lecture seule
@@ -614,14 +614,19 @@ cap_map_info=Informations
 cap_map_cur_search_terms=Termes de recherche courants
 cap_map_text6=Cet espace présente la liste des termes de la recherche en cours dans la cartographie. Inscrire un terme de recherche pour débuter.
 cap_map_text7=Cet espace affiche de l'information relative aux termes et groupes de termes. Cliquer sur un groupe pour afficher les informations qui y sont associées.
-
+cap_map_key1=capacité
+cap_map_key2=lien
+cap_map_key3=groupe
+cap_map_key4=2 liens
+cap_map_key5=3 liens
+cap_map_key6=>=4 liens
 
 #
 #  custom form javascript variables ( /templates/freemarker/edit/js)
 #
 drag_drop_reorder_authors = Glisser-déposer pour réorganiser les auteur(e)s
 reordering_authors_failed = Il a été impossible de réordonner les auteur(e)s
-confirm_author_removal = Êtes-vous certain de vouloir retirer cet auteur(e): 
+confirm_author_removal = Êtes-vous certain de vouloir retirer cet auteur(e):
 error_processing_author_request = Erreur lors du traitement de la demande: l'auteur(e) n'a pas été retiré(e)
 author_capitalized = Auteur(e)
 or_add_new_one = ou en ajouter un nouveau.
@@ -690,7 +695,7 @@ level_undefined_error = ERREUR INCONNUE DE NIVEAU ENTITE
 
 total_number_of = Nombre total de
 number_of = Nombre de
-have_an_unknown = a un inconnu  
+have_an_unknown = a un inconnu
 year_not_chartered = année (non indiquée dans le tableau ci-dessus)
 in_completed_year = dans une année complète
 were = où
@@ -776,13 +781,13 @@ add_an_editor = Ajouter un(e) éditeur(-trice)
 add_editor = Ajouter Éditeur(-trice)
 please_select_type = SVP, sélectionner un type dans la liste déroulante.
 preferred_title = Titre préféré
-preferred_title_for = Titre préféré pour 
+preferred_title_for = Titre préféré pour
 enter_preferred_title = Inscrire une valeur dans le champ Titre préféré.
 fax_number_for = numéro de télécopieur pour
 fax_number = Numéro de télécopieur
 enter_fax_number = SVP, inscrire une valeur dans le champ Numéro de télécopieur.
 credentials = diplômes
-select_credential_or_enter_name = Veuillez entrer ou sélectionner une valeur dans le champ Diplômes. 
+select_credential_or_enter_name = Veuillez entrer ou sélectionner une valeur dans le champ Diplômes.
 type_of_credential = Type de diplôme
 credential_name = Nom du diplôme
 selected_credential = Diplôme choisi
@@ -924,7 +929,7 @@ create_and_link_type_chapter=Chapitre
 create_and_link_type_dataset=Jeu de données
 create_and_link_type_figure=Image
 create_and_link_type_graphic=Image
-create_and_link_type_legal_case=Document juridique 
+create_and_link_type_legal_case=Document juridique
 create_and_link_type_legislation=Législation
 create_and_link_type_manuscript=Manuscrit
 create_and_link_type_map=Carte
@@ -938,6 +943,6 @@ create_and_link_type_review=Critique
 create_and_link_type_speech=Speech
 create_and_link_type_thesis=Discours
 create_and_link_type_webpage=Page web
-claim_publications_by=Publications revendiquées par 
+claim_publications_by=Publications revendiquées par
 claim_publications_by_doi=DOI
 claim_publications_by_pmid=Identifiant PubMed

--- a/pt_BR/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
+++ b/pt_BR/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
@@ -622,6 +622,12 @@ cap_map_info=Info
 cap_map_cur_search_terms=Termos de pesquisa atuais
 cap_map_text6=Este painel exibe uma lista dos termos de pesquisa atualmente no gráfico. Procure por algo para começar.
 cap_map_text7=Este painel exibe informações sobre o indivíduo Pesquisar termos e grupos. Clique em um grupo para exibir suas informações.
+cap_map_key1=capacidade
+cap_map_key2=borda
+cap_map_key3=grupo
+cap_map_key4=2 links
+cap_map_key5=3 links
+cap_map_key6=>= 4 links
 
 #
 #  custom form javascript variables ( /templates/freemarker/edit/js)


### PR DESCRIPTION
 - fixed types, added formerly missing properties and files

This is the work of @matthiasluehr... rebased for merge into `sprint-i18n`.

Supersedes: https://github.com/vivo-project/VIVO-languages/pull/66