### PR TITLE
Changed arguments of replace method to accommodate thousands separators in French

### DIFF
--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/lib/lib-home-page_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/lib/lib-home-page_fr_CA.ftl
@@ -39,7 +39,7 @@
                 <#if (class.uri?contains("FacultyMember")) >
                     <#assign foundClassGroup = true />
                     <#if (class.individualCount > 0) >
-                        <script>var facultyMemberCount = ${class.individualCount?string?replace(",","")?replace(".","")};</script>
+                        <script>var facultyMemberCount = ${class.individualCount?string?replace('^\\d', '', 'r')};</script>
                     <#else>
                         <script>var facultyMemberCount = 0;</script>
                     </#if>


### PR DESCRIPTION
Fixes https://jira.lyrasis.org/browse/VIVO-1824

The previous method in lib-home-page_fr_CA.ftl templates removed dots or commas in order to pass a purely numerical variable to the JavaScript. That method worked fine in English. However, in a different linguistic content -- such as French --, the thousands separator might be a space. When this happens, the script fails to clean the string and produces an incorrectly formed variable, which breaks the Ajax calls in the homepage Faculty widget.

Instead of removing some specific characters, this fix proposes to cover all possible cases, regardless of linguistic context, by removing any non-numerical characters.