### PR TITLE
Update references to ResearcherID

### DIFF
--- a/de_DE/home/src/main/resources/rdf/i18n/de_DE/tbox/everytime/initialTBoxAnnotations_de_DE.nt
+++ b/de_DE/home/src/main/resources/rdf/i18n/de_DE/tbox/everytime/initialTBoxAnnotations_de_DE.nt
@@ -376,7 +376,7 @@
 <http://purl.org/ontology/bibo/Bill> <http://www.w3.org/2000/01/rdf-schema#label> "Gesetzesentwurf"@de-DE .
 <http://vivoweb.org/ontology/core#dateTimeInterval> <http://www.w3.org/2000/01/rdf-schema#label> "Datum/Uhrzeit-Intervall"@de-DE .
 <http://vivoweb.org/ontology/core#end> <http://www.w3.org/2000/01/rdf-schema#label> "Ende"@de-DE .
-<http://vivoweb.org/ontology/core#researcherId> <http://www.w3.org/2000/01/rdf-schema#label> "ISI Researcher ID"@de-DE .
+<http://vivoweb.org/ontology/core#researcherId> <http://www.w3.org/2000/01/rdf-schema#label> "ResearcherID"@de-DE .
 <http://vivoweb.org/ontology/core#sponsors> <http://www.w3.org/2000/01/rdf-schema#label> "Auszeichnung oder Preis der Sponsoren"@de-DE .
 <http://purl.org/ontology/bibo/upc> <http://www.w3.org/2000/01/rdf-schema#label> "Universal Product Code (UPC)"@de-DE .
 <http://vivoweb.org/ontology/core#Licensure> <http://www.w3.org/2000/01/rdf-schema#label> "Approbation"@de-DE .

--- a/de_DE/home/src/main/resources/rdf/i18n/de_DE/tbox/filegraph/vivo_de_DE.ttl
+++ b/de_DE/home/src/main/resources/rdf/i18n/de_DE/tbox/filegraph/vivo_de_DE.ttl
@@ -1345,7 +1345,7 @@
 
 <http://vivoweb.org/ontology/core#researchOverview> rdfs:label "Übersicht zur Forschung"@de-DE .
 
-<http://vivoweb.org/ontology/core#researcherId> rdfs:label "ISI Researcher ID"@de-DE .
+<http://vivoweb.org/ontology/core#researcherId> rdfs:label "ResearcherID"@de-DE .
 
 <http://vivoweb.org/ontology/core#reviewedIn> rdfs:label "rezensiert in"@de-DE .
 

--- a/de_DE/home/src/main/resources/rdf/i18n/de_DE/tbox/firsttime/vitroAnnotations_de_DE.n3
+++ b/de_DE/home/src/main/resources/rdf/i18n/de_DE/tbox/firsttime/vitroAnnotations_de_DE.n3
@@ -4390,7 +4390,7 @@ vivo:researcherId
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
       vitro:publicDescriptionAnnot
-              "Die Identifikationsnummer des Profils in ResearcherID (http://isiwebofknowledge.com/researcherid/)."@de-DE .		  
+              "Die Identifikationsnummer des Profils in ResearcherID (https://researcherid.com/)."@de-DE
 
 vivo:hasPublicationVenue
       vitro:displayLimitAnnot
@@ -7555,6 +7555,4 @@ vivo:assignedBy
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> ;
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#nobody> .
-
-
 

--- a/en_CA/home/src/main/resources/rdf/i18n/en_CA/tbox/everytime/initialTBoxAnnotations_en_CA.nt
+++ b/en_CA/home/src/main/resources/rdf/i18n/en_CA/tbox/everytime/initialTBoxAnnotations_en_CA.nt
@@ -875,5 +875,5 @@
 <http://purl.obolibrary.org/obo/ARG_2000078> <http://www.w3.org/2000/01/rdf-schema#label> "American Board of Otolaryngology"@en-CA .
 <http://www.w3.org/2006/vcard/ns#Key> <http://www.w3.org/2000/01/rdf-schema#label> "Key"@en-CA .
 <http://vivoweb.org/ontology/core#hasMonetaryAmount> <http://www.w3.org/2000/01/rdf-schema#label> "has monetary amount"@en-CA .
-<http://vivoweb.org/ontology/core#researcherId> <http://www.w3.org/2000/01/rdf-schema#label> "ISI Researcher ID"@en-CA .
+<http://vivoweb.org/ontology/core#researcherId> <http://www.w3.org/2000/01/rdf-schema#label> "ResearcherID"@en-CA .
 <http://vivoweb.org/ontology/core#ExtensionUnit> <http://www.w3.org/2000/01/rdf-schema#label> "Extension Unit"@en-CA .

--- a/en_US/home/src/main/resources/rdf/i18n/en_US/tbox/everytime/initialTBoxAnnotations_en_US.nt
+++ b/en_US/home/src/main/resources/rdf/i18n/en_US/tbox/everytime/initialTBoxAnnotations_en_US.nt
@@ -496,7 +496,7 @@
 <http://www.obofoundry.org/ro/ro.owl#has_agent> <http://www.w3.org/2000/01/rdf-schema#label> "has agent"@en-US .
 <http://purl.org/ontology/bibo/published> <http://www.w3.org/2000/01/rdf-schema#label> "published"@en-US .
 <http://vivoweb.org/ontology/core#AcademicDepartment> <http://www.w3.org/2000/01/rdf-schema#label> "Academic Department"@en-US .
-<http://vivoweb.org/ontology/core#researcherId> <http://www.w3.org/2000/01/rdf-schema#label> "ISI Researcher ID"@en-US .
+<http://vivoweb.org/ontology/core#researcherId> <http://www.w3.org/2000/01/rdf-schema#label> "ResearcherID"@en-US .
 <http://vivoweb.org/ontology/core#hasPublicationVenue> <http://www.w3.org/2000/01/rdf-schema#label> "published in"@en-US .
 <http://purl.org/ontology/bibo/Excerpt> <http://www.w3.org/2000/01/rdf-schema#label> "Excerpt"@en-US .
 <http://vivoweb.org/ontology/core#NonFacultyAcademic> <http://www.w3.org/2000/01/rdf-schema#label> "Non-Faculty Academic"@en-US .

--- a/en_US/home/src/main/resources/rdf/i18n/en_US/tbox/firsttime/vitroAnnotations_en_US.n3
+++ b/en_US/home/src/main/resources/rdf/i18n/en_US/tbox/firsttime/vitroAnnotations_en_US.n3
@@ -4389,7 +4389,7 @@ vivo:researcherId
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
       vitro:publicDescriptionAnnot
-              "The identification number given to the profile created by a researcher in ResearcherID (http://isiwebofknowledge.com/researcherid/)."@en-US .
+              "The identification number given to the profile created by a researcher in ResearcherID (https://researcherid.com/)."@en-US .
 
 vivo:hasPublicationVenue
       vitro:displayLimitAnnot

--- a/es/home/src/main/resources/rdf/i18n/es/tbox/everytime/initialTBoxAnnotations_es.nt
+++ b/es/home/src/main/resources/rdf/i18n/es/tbox/everytime/initialTBoxAnnotations_es.nt
@@ -491,7 +491,7 @@
 <http://www.obofoundry.org/ro/ro.owl#has_agent> <http://www.w3.org/2000/01/rdf-schema#label> "tiene agente"@es .
 <http://purl.org/ontology/bibo/published> <http://www.w3.org/2000/01/rdf-schema#label> "Publicado"@es .
 <http://vivoweb.org/ontology/core#AcademicDepartment> <http://www.w3.org/2000/01/rdf-schema#label> "Departamento acad\u00E9mico"@es .
-<http://vivoweb.org/ontology/core#researcherId> <http://www.w3.org/2000/01/rdf-schema#label> "Identificador de investigador ISI"@es .
+<http://vivoweb.org/ontology/core#researcherId> <http://www.w3.org/2000/01/rdf-schema#label> "ResearcherID"@es .
 <http://vivoweb.org/ontology/core#hasPublicationVenue> <http://www.w3.org/2000/01/rdf-schema#label> "Publicado en"@es .
 <http://purl.org/ontology/bibo/Excerpt> <http://www.w3.org/2000/01/rdf-schema#label> "Extracto"@es .
 <http://vivoweb.org/ontology/core#NonFacultyAcademic> <http://www.w3.org/2000/01/rdf-schema#label> "Facultad no acad\u00E9mica"@es .

--- a/fr_CA/home/src/main/resources/rdf/i18n/fr_CA/tbox/everytime/initialTBoxAnnotations_fr_CA.nt
+++ b/fr_CA/home/src/main/resources/rdf/i18n/fr_CA/tbox/everytime/initialTBoxAnnotations_fr_CA.nt
@@ -497,7 +497,7 @@
 <http://www.obofoundry.org/ro/ro.owl#has_agent> <http://www.w3.org/2000/01/rdf-schema#label> "agent"@fr-CA .
 <http://purl.org/ontology/bibo/published> <http://www.w3.org/2000/01/rdf-schema#label> "publié"@fr-CA .
 <http://vivoweb.org/ontology/core#AcademicDepartment> <http://www.w3.org/2000/01/rdf-schema#label> "Département"@fr-CA .
-<http://vivoweb.org/ontology/core#researcherId> <http://www.w3.org/2000/01/rdf-schema#label> "ID de chercheur ISI"@fr-CA .
+<http://vivoweb.org/ontology/core#researcherId> <http://www.w3.org/2000/01/rdf-schema#label> "ResearcherID"@fr-CA .
 <http://vivoweb.org/ontology/core#hasPublicationVenue> <http://www.w3.org/2000/01/rdf-schema#label> "publié dans"@fr-CA .
 <http://purl.org/ontology/bibo/Excerpt> <http://www.w3.org/2000/01/rdf-schema#label> "Extrait"@fr-CA .
 <http://vivoweb.org/ontology/core#NonFacultyAcademic> <http://www.w3.org/2000/01/rdf-schema#label> "Enseignant"@fr-CA .

--- a/fr_CA/home/src/main/resources/rdf/i18n/fr_CA/tbox/filegraph/vivo_fr_CA.ttl
+++ b/fr_CA/home/src/main/resources/rdf/i18n/fr_CA/tbox/filegraph/vivo_fr_CA.ttl
@@ -2060,7 +2060,7 @@ core:researchOverview
   rdfs:label "Aperçu de la recherche"@fr-CA ;
 .
 core:researcherId
-  rdfs:label "ID de chercheur ISI"@fr-CA ;
+  rdfs:label "ResearcherID"@fr-CA ;
 .
 core:reviewedIn
   rdfs:label "analysé dans"@fr-CA ;

--- a/fr_CA/home/src/main/resources/rdf/i18n/fr_CA/tbox/firsttime/vitroAnnotations_fr_CA.ttl
+++ b/fr_CA/home/src/main/resources/rdf/i18n/fr_CA/tbox/firsttime/vitroAnnotations_fr_CA.ttl
@@ -4011,7 +4011,7 @@ vivo:researcherId
   vitro:hiddenFromPublishBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#selfEditor> ;
   vitro:inPropertyGroupAnnot <http://vivoweb.org/ontology#vitroPropertyGroupidentifiers> ;
   vitro:prohibitedFromUpdateBelowRoleLevelAnnot <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
-  vitro:publicDescriptionAnnot "Le numéro d'identification donné au profil créé par un chercheur dans ResearcherID (http://isiwebofknowledge.com/researcherid/)."@fr-CA ;
+  vitro:publicDescriptionAnnot "Le numéro d'identification donné au profil créé par un chercheur dans ResearcherID (https://researcherid.com/)."@fr-CA ;
 .
 vivo:reviewedIn
   vitro:displayLimitAnnot "5"^^xsd:int ;

--- a/pt_BR/home/src/main/resources/rdf/i18n/pt_BR/tbox/everytime/initialTBoxAnnotations_pt_BR.nt
+++ b/pt_BR/home/src/main/resources/rdf/i18n/pt_BR/tbox/everytime/initialTBoxAnnotations_pt_BR.nt
@@ -491,7 +491,7 @@
 <http://www.obofoundry.org/ro/ro.owl#has_agent> <http://www.w3.org/2000/01/rdf-schema#label> "tem agente"@pt-BR .
 <http://purl.org/ontology/bibo/published> <http://www.w3.org/2000/01/rdf-schema#label> "publicada"@pt-BR .
 <http://vivoweb.org/ontology/core#AcademicDepartment> <http://www.w3.org/2000/01/rdf-schema#label> "Departamento acadêmico"@pt-BR .
-<http://vivoweb.org/ontology/core#researcherId> <http://www.w3.org/2000/01/rdf-schema#label> "ISI Researcher ID"@pt-BR .
+<http://vivoweb.org/ontology/core#researcherId> <http://www.w3.org/2000/01/rdf-schema#label> "ResearcherID"@pt-BR .
 <http://vivoweb.org/ontology/core#hasPublicationVenue> <http://www.w3.org/2000/01/rdf-schema#label> "publicada em"@pt-BR .
 <http://purl.org/ontology/bibo/Excerpt> <http://www.w3.org/2000/01/rdf-schema#label> "Trecho"@pt-BR .
 <http://vivoweb.org/ontology/core#NonFacultyAcademic> <http://www.w3.org/2000/01/rdf-schema#label> "Não Corpo docente acadêmico"@pt-BR .


### PR DESCRIPTION
Updated version of https://github.com/vivo-project/VIVO-languages/pull/69 that conforms to the new directory structure in the sprint-i18n branches.

See https://github.com/vivo-project/VIVO/pull/188 for companion pull request and description and https://jira.lyrasis.org/browse/VIVO-1946 for the Jira issue.