### PR TITLE
[VIVO-1734] - Remove unnecessary mentions of "One-time permission" from language files

### DIFF
--- a/en_CA/webapp/src/main/webapp/i18n/vivo_all_en_CA.properties
+++ b/en_CA/webapp/src/main/webapp/i18n/vivo_all_en_CA.properties
@@ -858,7 +858,7 @@ orcid_step1_confirm = Step 1: Adding your ORCID iD
 
 orcid_step1_description = <ul><li>VIVO redirects you to ORCID's web site.</li> \
 <li>You log in to your ORCID account. <ul class="inner"><li>If you don't have an account, you can create one.</li></ul></li> \
-<li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may read your ORCID record.</li> \
 <li>VIVO reads your ORCID record.</li> \
 <li>VIVO notes that your ORCID iD is confirmed.</li></ul>
 
@@ -873,7 +873,7 @@ orcid_step1_confirmed = <p>Your ORCID iD is confirmed as {0}</p>
 orcid_step2_heading = Step 2 (recommended): Linking your ORCID record to VIVO
 
 orcid_step2_description = <ul><li>VIVO redirects you to ORCID's web site</li> \
-<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record.</li> \
 <li>VIVO adds the external ID.</li></ul>
 
 orcid_step2_already_present = <p>Your ORCID record already includes a link to VIVO.</p>

--- a/en_US/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
+++ b/en_US/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
@@ -858,7 +858,7 @@ orcid_step1_confirm = Step 1: Adding your ORCID iD
 
 orcid_step1_description = <ul><li>VIVO redirects you to ORCID's web site.</li> \
 <li>You log in to your ORCID account. <ul class="inner"><li>If you don't have an account, you can create one.</li></ul></li> \
-<li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may read your ORCID record.</li> \
 <li>VIVO reads your ORCID record.</li> \
 <li>VIVO notes that your ORCID iD is confirmed.</li></ul>
 
@@ -873,7 +873,7 @@ orcid_step1_confirmed = <p>Your ORCID iD is confirmed as {0}</p>
 orcid_step2_heading = Step 2 (recommended): Linking your ORCID record to VIVO
 
 orcid_step2_description = <ul><li>VIVO redirects you to ORCID's web site</li> \
-<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record.</li> \
 <li>VIVO adds the external ID.</li></ul>
 
 orcid_step2_already_present = <p>Your ORCID record already includes a link to VIVO.</p>

--- a/es/webapp/src/main/webapp/i18n/vivo_all_es.properties
+++ b/es/webapp/src/main/webapp/i18n/vivo_all_es.properties
@@ -860,7 +860,7 @@ orcid_step1_confirm = Step 1: Adding your ORCID iD
 
 orcid_step1_description = <ul><li>VIVO redirects you to ORCID's web site.</li> \
 <li>You log in to your ORCID account. <ul class="inner"><li>If you don't have an account, you can create one.</li></ul></li> \
-<li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may read your ORCID record.</li> \
 <li>VIVO reads your ORCID record.</li> \
 <li>VIVO notes that your ORCID iD is confirmed.</li></ul>
 
@@ -875,7 +875,7 @@ orcid_step1_confirmed = <p>Your ORCID iD is confirmed as {0}</p>
 orcid_step2_heading = Step 2 (recommended): Linking your ORCID record to VIVO
 
 orcid_step2_description = <ul><li>VIVO redirects you to ORCID's web site</li> \
-<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record.</li> \
 <li>VIVO adds the external ID.</li></ul>
 
 orcid_step2_already_present = <p>Your ORCID record already includes a link to VIVO.</p>

--- a/pt_BR/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
+++ b/pt_BR/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
@@ -859,7 +859,7 @@ orcid_step1_confirm = Step 1: Adding your ORCID iD
 
 orcid_step1_description = <ul><li>VIVO redirects you to ORCID's web site.</li> \
 <li>You log in to your ORCID account. <ul class="inner"><li>If you don't have an account, you can create one.</li></ul></li> \
-<li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may read your ORCID record.</li> \
 <li>VIVO reads your ORCID record.</li> \
 <li>VIVO notes that your ORCID iD is confirmed.</li></ul>
 
@@ -874,7 +874,7 @@ orcid_step1_confirmed = <p>Your ORCID iD is confirmed as {0}</p>
 orcid_step2_heading = Step 2 (recommended): Linking your ORCID record to VIVO
 
 orcid_step2_description = <ul><li>VIVO redirects you to ORCID's web site</li> \
-<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record.</li> \
 <li>VIVO adds the external ID.</li></ul>
 
 orcid_step2_already_present = <p>Your ORCID record already includes a link to VIVO.</p>


### PR DESCRIPTION
https://jira.duraspace.org/browse/VIVO-1734

Teases out relevant changes originally proposed by @hauschke in https://github.com/vivo-project/VIVO-languages/pull/26