### PR TITLE
Modified addRoleToPersonTwoStage_fr_CA.ftl and .properties files to accomodate French grammar

### DIFF
--- a/fr_CA/webapp/src/main/webapp/i18n/vivo_all_fr_CA.properties
+++ b/fr_CA/webapp/src/main/webapp/i18n/vivo_all_fr_CA.properties
@@ -241,7 +241,7 @@ year_hint_format = AAAA
 
 collection_series_editor_role = Rôle d'éditeur(-trice) de collection
 editor_role_in = rôle d'éditeur(-trice) dans
-collection_or_series = la collection ou la série
+collection_or_series = collection ou série
 
 edit_wbpage_of = Éditer la page web de
 add_webpage_for = Ajouter la page web de

--- a/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage_fr_CA.ftl
+++ b/fr_CA/webapp/src/main/webapp/templates/freemarker/edit/forms/addRoleToPersonTwoStage_fr_CA.ftl
@@ -130,8 +130,16 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 
     <form id="add${roleDescriptor?cap_first}RoleToPersonTwoStage" class="customForm noIE67" action="${submitUrl}"  role="add/edit grant role">
 
-       <p class="inline">
-        <label for="typeSelector">${typeSelectorLabel?cap_first}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
+            <#if showRoleLabelField = true>
+            <p><label for="roleLabel" class="inline">${i18n().user_role} ${roleExamples}</label>
+                <input  size="50"  type="text" id="roleLabel" name="roleLabel" value="${roleLabel}" />
+            </p>
+            </#if>
+
+      <h3>${genericLabel?cap_first}</h3>
+
+       <p>
+        <label for="typeSelector" class="inline">${i18n().type_capitalized?cap_first}<#if editMode != "edit"> ${requiredHint}<#else>:</#if></label>
         <#--Code below allows for selection of first 'select one' option if no activity type selected-->
         <#if activityTypeValue?has_content>
         	<#assign selectedActivityType = activityTypeValue />
@@ -163,7 +171,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
 		Adaptation of structure for french 
  -->
             <p>
-                <label for="activity">${i18n().name_of?cap_first} l'${genericLabel?lower_case}  ${requiredHint}</label>
+                <label for="activity" class="inline">${i18n().name?cap_first} ${requiredHint}</label>
                 <input class="acSelector" size="50"  type="text" id="activity" name="activityLabel"  acGroupName="activity" value="${activityLabelValue}" />
                 <input class="display" type="hidden" id="activityDisplay" acGroupName="activity" name="activityLabelDisplay" value="${activityLabelDisplayValue}">
             </p>
@@ -183,12 +191,6 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
                     <!-- Field value populated by JavaScript -->
             </div>
 
-            <#if showRoleLabelField = true>
-            <p><label for="roleLabel">${i18n().role_in} l'${genericLabel?lower_case} ${roleExamples}</label>
-                <input  size="50"  type="text" id="roleLabel" name="roleLabel" value="${roleLabel}" />
-            </p>
-        	</#if>
-
             <#if numDateFields == 1 >
                <#--Generated html is a map with key name mapping to html string-->
                <#if htmlForElements?keys?seq_contains("startField")>
@@ -196,7 +198,7 @@ Set this flag on the input acUriReceiver where you would like this behavior to o
                		${htmlForElements["startField"]} ${yearHint}
                </#if>
             <#else>
-                <h4 class="label">${i18n().years_participating} </h4>
+                <h3 class="label">${i18n().years_participating} </h3>
                 <#if htmlForElements?keys?seq_contains("startField")>
                 	    <label class="dateTime" for="startField">${i18n().start_year}</label>
                		    ${htmlForElements["startField"]} ${yearHint}

--- a/fr_CA/webapp/src/main/webapp/themes/tenderfoot/i18n/all_fr_CA.properties
+++ b/fr_CA/webapp/src/main/webapp/themes/tenderfoot/i18n/all_fr_CA.properties
@@ -52,7 +52,7 @@ grant_date = date de la subvention
 loading_data = chargement des données
 to = à
 collection_capitalized = Collection
-collection_or_series = la collection ou la série
+collection_or_series = collection ou série
 
 create_entry = Créer un enregistrement
 first_grant = Première subvention

--- a/fr_CA/webapp/src/main/webapp/themes/wilma/i18n/all_fr_CA.properties
+++ b/fr_CA/webapp/src/main/webapp/themes/wilma/i18n/all_fr_CA.properties
@@ -25,7 +25,7 @@ identity_myaccount = Mon compte
 identity_user = utilisateur(-trice)
 
 collection_capitalized = Collection
-collection_or_series = la collection ou la série
+collection_or_series = collection ou série
 place_of_grant = Lieu de la subvention
 email_address = Courriel
 


### PR DESCRIPTION
Resolves https://jira.lyrasis.org/browse/VIVO-1797

### What it does

The file addRoleToPersonTwoStage_fr_CA.ftl was modified so VIVO won't try to generate sentences, but rather organize the fields in a hierarchical manner:

![image](https://user-images.githubusercontent.com/46490666/105762265-2ccb9b80-5f22-11eb-8769-c7b7bc99fbad.png)
 
### How to test it

In the fr_CA context, go to a person profile, then Publications > Responsable de collection > Add
