### PR TITLE
Fix for RDF error introduced in 60933a5  

### DIFF
--- a/de_DE/home/src/main/resources/rdf/i18n/de_DE/tbox/firsttime/vitroAnnotations_de_DE.n3
+++ b/de_DE/home/src/main/resources/rdf/i18n/de_DE/tbox/firsttime/vitroAnnotations_de_DE.n3
@@ -4390,7 +4390,7 @@ vivo:researcherId
       vitro:prohibitedFromUpdateBelowRoleLevelAnnot
               <http://vitro.mannlib.cornell.edu/ns/vitro/role#public> ;
       vitro:publicDescriptionAnnot
-              "Die Identifikationsnummer des Profils in ResearcherID (https://researcherid.com/)."@de-DE
+              "Die Identifikationsnummer des Profils in ResearcherID (https://researcherid.com/)."@de-DE .
 
 vivo:hasPublicationVenue
       vitro:displayLimitAnnot


### PR DESCRIPTION
Return missing period to its rightful home.
Simply add back in a period that was mistakenly removed as part of https://github.com/vivo-project/VIVO-languages/pull/76/files#diff-fbfd4b2177c3dae0bbeb4a6d52a553a01120d3313d2959403a78ad58d5d98369L4393