### PR TITLE
Remove plugin duplicates

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -152,19 +152,6 @@
                             <revisionOnScmFailure>Detached</revisionOnScmFailure>
                         </configuration>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile> 

--- a/de_DE/pom.xml
+++ b/de_DE/pom.xml
@@ -147,19 +147,6 @@
                             <revisionOnScmFailure>Detached</revisionOnScmFailure>
                         </configuration>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile> 

--- a/en_CA/pom.xml
+++ b/en_CA/pom.xml
@@ -152,19 +152,6 @@
                             <revisionOnScmFailure>Detached</revisionOnScmFailure>
                         </configuration>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile> 

--- a/en_US/pom.xml
+++ b/en_US/pom.xml
@@ -152,19 +152,6 @@
                             <revisionOnScmFailure>Detached</revisionOnScmFailure>
                         </configuration>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile> 

--- a/es/pom.xml
+++ b/es/pom.xml
@@ -152,19 +152,6 @@
                             <revisionOnScmFailure>Detached</revisionOnScmFailure>
                         </configuration>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile> 

--- a/fr_CA/pom.xml
+++ b/fr_CA/pom.xml
@@ -152,19 +152,6 @@
                             <revisionOnScmFailure>Detached</revisionOnScmFailure>
                         </configuration>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile> 

--- a/pom.xml
+++ b/pom.xml
@@ -143,19 +143,6 @@
                             <revisionOnScmFailure>Detached</revisionOnScmFailure>
                         </configuration>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile> 

--- a/pt_BR/pom.xml
+++ b/pt_BR/pom.xml
@@ -153,19 +153,6 @@
                             <revisionOnScmFailure>Detached</revisionOnScmFailure>
                         </configuration>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile> 


### PR DESCRIPTION
Remove duplicate declarations of maven-gpg-plugin from pom files. 
This resolves warning during VIVO building.