### PR TITLE
Typo fixes

### DIFF
--- a/en_US/home/src/main/resources/rdf/i18n/en_US/tbox/firsttime/initialTBoxAnnotations_en_US.nt
+++ b/en_US/home/src/main/resources/rdf/i18n/en_US/tbox/firsttime/initialTBoxAnnotations_en_US.nt
@@ -633,7 +633,6 @@
 <http://www.w3.org/2006/vcard/ns#Work> <http://www.w3.org/2000/01/rdf-schema#label> "Work"@en-US .
 <http://purl.obolibrary.org/obo/ARG_2000012> <http://www.w3.org/2000/01/rdf-schema#label> "Measurement Label"@en-US .
 <http://purl.obolibrary.org/obo/ERO_0000780> <http://www.w3.org/2000/01/rdf-schema#label> "Non-Permanent Resident Role"@en-US .
-<http://purl.org/ontology/bibo/> <http://www.w3.org/2000/01/rdf-schema#label> "Bibontology"@en-US .
 <http://purl.org/net/OCRe/research.owl> <http://www.w3.org/2000/01/rdf-schema#label> "OCRe research"@en-US .
 <http://aims.fao.org/aos/geopolitical.owl#special_group> <http://www.w3.org/2000/01/rdf-schema#label> "Special Group"@en-US .
 <http://aims.fao.org/aos/geopolitical.owl#countryAreaUnit> <http://www.w3.org/2000/01/rdf-schema#label> "country area unit"@en-US .
@@ -863,7 +862,6 @@
 <http://www.w3.org/2006/vcard/ns#Location> <http://www.w3.org/2000/01/rdf-schema#label> "Location"@en-US .
 <http://purl.obolibrary.org/obo/RO_0001015> <http://www.w3.org/2000/01/rdf-schema#label> "location of"@en-US .
 <http://www.w3.org/2006/vcard/ns#OrganizationUnitName> <http://www.w3.org/2000/01/rdf-schema#label> "Organizational Unit Name"@en-US .
-<http://vivoweb.org/ontology/core> <http://www.w3.org/2000/01/rdf-schema#label> "VIVO Core"@en-US .
 <http://vivoweb.org/ontology/core#dateTime> <http://www.w3.org/2000/01/rdf-schema#label> "date/time"@en-US .
 <http://aims.fao.org/aos/geopolitical.owl#codeUN> <http://www.w3.org/2000/01/rdf-schema#label> "codeUN"@en-US .
 <http://purl.obolibrary.org/obo/OBI_0000011> <http://www.w3.org/2000/01/rdf-schema#label> "Planned Process"@en-US .

--- a/fr_CA/home/src/main/resources/rdf/i18n/fr_CA/tbox/firsttime/initialTBoxAnnotations_fr_CA.nt
+++ b/fr_CA/home/src/main/resources/rdf/i18n/fr_CA/tbox/firsttime/initialTBoxAnnotations_fr_CA.nt
@@ -28,7 +28,7 @@
 <http://purl.org/ontology/bibo/sici> <http://www.w3.org/2000/01/rdf-schema#label> "Serial Item and Contribution Identifier (SICI)"@fr-CA .
 <http://vivoweb.org/ontology/core#Licensure> <http://www.w3.org/2000/01/rdf-schema#label> "Permis d'exercer"@fr-CA .
 <http://vivoweb.org/ontology/core#inPress> <http://www.w3.org/2000/01/rdf-schema#label> "sous presse"@fr-CA .
-<http://vivoweb.org/ontology/core#placeOfPublition> <http://www.w3.org/2000/01/rdf-schema#label> "lieu de publication"@fr-CA .
+<http://vivoweb.org/ontology/core#placeOfPublication> <http://www.w3.org/2000/01/rdf-schema#label> "lieu de publication"@fr-CA .
 <http://vivoweb.org/ontology/core#hasCollaborator> <http://www.w3.org/2000/01/rdf-schema#label> "collaborateurs"@fr-CA .
 <http://vivoweb.org/ontology/core#GovernmentAgency> <http://www.w3.org/2000/01/rdf-schema#label> "Agence gouvernementale"@fr-CA .
 <http://www.w3.org/2004/02/skos/core#narrower> <http://www.w3.org/2000/01/rdf-schema#label> "concept plus précis"@fr-CA .


### PR DESCRIPTION
Fixed typo in French localization.
Removed duplicate entries from English localization.

Duplicate entries 1:
https://github.com/vivo-project/VIVO-languages/blob/1ec033532798fa46f13c459db0cc2c52dca77788/en_US/home/src/main/resources/rdf/i18n/en_US/tbox/firsttime/initialTBoxAnnotations_en_US.nt#L636
https://github.com/vivo-project/VIVO-languages/blob/1ec033532798fa46f13c459db0cc2c52dca77788/en_US/home/src/main/resources/rdf/i18n/en_US/tbox/firsttime/initialTBoxAnnotations_en_US.nt#L878

Duplicate entries 2:
https://github.com/vivo-project/VIVO-languages/blob/1ec033532798fa46f13c459db0cc2c52dca77788/en_US/home/src/main/resources/rdf/i18n/en_US/tbox/firsttime/initialTBoxAnnotations_en_US.nt#L866
https://github.com/vivo-project/VIVO-languages/blob/1ec033532798fa46f13c459db0cc2c52dca77788/en_US/home/src/main/resources/rdf/i18n/en_US/tbox/firsttime/initialTBoxAnnotations_en_US.nt#L879
 