### PR TITLE
Remove non-language-tag-related content from i18n initialSiteConfig files

### DIFF
--- a/de_DE/home/src/main/resources/rdf/i18n/de_DE/applicationMetadata/firsttime/initialSiteConfig_de_DE.ttl
+++ b/de_DE/home/src/main/resources/rdf/i18n/de_DE/applicationMetadata/firsttime/initialSiteConfig_de_DE.ttl
@@ -15,7 +15,5 @@
         Systemen in die Datenbasis gebracht werden, wie z. B. Förderprojekte, Kurse oder anderen lokal vorhandenen Datenbeständen.
         </p><p>Für mehr Informationen folgen Sie diesem Link: <a href=\"http://vivoweb.org\">VIVO Project</a>
         .</p>"""@de-DE ;
-  vitro:shortHand "connect * share * discover" ;
-  vitro:themeDir "themes/wilma/" ;
   rdfs:label "VIVO"@de-DE ;
 ].

--- a/fr_CA/home/src/main/resources/rdf/i18n/fr_CA/applicationMetadata/firsttime/initialSiteConfig_fr_CA.ttl
+++ b/fr_CA/home/src/main/resources/rdf/i18n/fr_CA/applicationMetadata/firsttime/initialSiteConfig_fr_CA.ttl
@@ -9,15 +9,5 @@
 
 [
   a vitro:Portal ;
-  vitro:aboutText """<p>VIVO is an open source semantic
-        web application originally developed and implemented at Cornell. When installed and populated with content at
-        an institution, it enables the discovery of research and scholarship across disciplines at that institution.
-        VIVO supports browsing and a search function which returns faceted results for rapid retrieval of desired
-        information. Content in any local VIVO installation may be maintained manually or brought into the database
-        in automated ways from local systems of record, such as HR, grants, course, and faculty activity databases.
-        </p><p>See more information on the <a href=\"http://vivoweb.org\">VIVO Project</a>
-        .</p>""" ;
-  vitro:shortHand "connect * share * discover" ;
-  vitro:themeDir "themes/wilma/" ;
-  rdfs:label "VIVO"@en-US ;
+  rdfs:label "VIVO"@fr-CA ;
 ].


### PR DESCRIPTION
**[VIVO GitHub issue VIVO-3714](https://github.com/vivo-project/VIVO/issues/3714)**

# What does this pull request do?
- Removes themeDir declarations from fr-CA and de-DE initialSiteConfig files.  The default themeDir should be defined only once, in VIVO (not VIVO-languages) home/src/main/resources/rdf/applicationMetadata/firsttime/initialSiteConfig.rdf.
- Removes untranslated triples.
- Changes an en-US tag to fr-CA to align with its language folder.

# How should this be tested?
Should result in no functional changes.  Avoids any risk that the unnecessary themeDir properties will conflict with desired themeDir setting.

@VIVO-project/vivo-committers